### PR TITLE
Use a unique provider alias

### DIFF
--- a/config/services/two_factor_provider.php
+++ b/config/services/two_factor_provider.php
@@ -14,6 +14,6 @@ return static function (ContainerConfigurator $container): void {
                 '$formRenderer' => abstract_arg('form renderer'),
                 '$clock' => service(ClockInterface::class),
             ])
-            ->tag('scheb_two_factor.provider', ['alias' => 'email'])
+            ->tag('scheb_two_factor.provider', ['alias' => 'db1337email'])
     ;
 };

--- a/tests/TwoFactorEmailBundleTest.php
+++ b/tests/TwoFactorEmailBundleTest.php
@@ -72,7 +72,7 @@ class TwoFactorEmailBundleTest extends TestCase
         $this->assertArrayHasKey(0, $tag);
         $this->assertIsArray($tag[0]);
         $this->assertArrayHasKey('alias', $tag[0]);
-        $this->assertEquals('email', $tag[0]['alias']);
+        $this->assertEquals('db1337email', $tag[0]['alias']);
     }
 
     #[Test]


### PR DESCRIPTION
Change provider name to "db1337email" to avoid possible confusion with official scheb/2fa-email package.